### PR TITLE
Support latest nightly; allow logging to stdout and stderr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,14 @@
 [package]
-name = "tracing-allocator"
-description = "track allocations and deallocations"
-license = "MIT"
-repository = "https://github.com/geal/tracing_allocator"
-readme = "README.md"
-keywords = ["allocator", "debugging"]
-categories = ["development-tools", "memory-management"]
-version = "0.1.0"
 authors = ["Geoffroy Couprie <geo.couprie@gmail.com>"]
+categories = ["development-tools", "memory-management"]
+description = "track allocations and deallocations"
+keywords = ["allocator", "debugging"]
+license = "MIT"
+name = "tracing-allocator"
+readme = "README.md"
+repository = "https://github.com/geal/tracing_allocator"
+version = "0.1.0"
 
 [dependencies]
 libc = "^0.2"
 time = "^0.1"
-

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,19 +1,21 @@
-#![feature(global_allocator)]
-
 extern crate tracing_allocator;
 
 use std::fs::File;
 
 #[global_allocator]
-static GLOBAL: tracing_allocator::Allocator = tracing_allocator::Allocator{};
+static GLOBAL: tracing_allocator::Allocator = tracing_allocator::Allocator {};
 
 fn main() {
-  let f = File::create("trace.txt").unwrap();
-  tracing_allocator::Allocator::initialize(&f);
-  tracing_allocator::Allocator::activate();
+    let f = File::create("trace.txt").unwrap();
+    //tracing_allocator::Allocator::initialize(&f);
+    tracing_allocator::Allocator::write_to_stderr();
+    tracing_allocator::Allocator::activate();
 
-  let s = String::from("Hello world!");
+    let s = String::from("Hello world!");
 
-  let mut v = Vec::new();
-  v.push(1);
+    let mut v = Vec::new();
+
+    v.push(1);
+
+    println!("{:?}", s);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,148 +1,187 @@
-#![feature(global_allocator, allocator_api, heap_api)]
+#![feature(allocator_api, maybe_uninit)]
 
 extern crate libc;
 extern crate time;
 
-use std::mem;
-use std::process;
-use std::fs::File;
-use std::os::unix::io::AsRawFd;
-use std::heap::{Alloc, System, Layout, AllocErr};
-use std::sync::atomic::{AtomicBool, ATOMIC_BOOL_INIT, Ordering};
 use libc::c_void;
+use std::alloc::{Alloc, AllocErr, GlobalAlloc, Layout, System};
+use std::fs::File;
+use std::mem;
+use std::os::unix::io::AsRawFd;
+use std::process;
+use std::ptr::{null_mut, NonNull};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-static mut TRACE_FD:i32 = -1;
-static TRACE_ACTIVATE: AtomicBool = ATOMIC_BOOL_INIT;
+static mut TRACE_FD: i32 = -1;
+static TRACE_ACTIVATE: AtomicBool = AtomicBool::new(false);
 
-pub struct Allocator {
-}
+pub struct Allocator {}
 
 impl Allocator {
-  pub fn new() -> Allocator {
-    Allocator {
+    pub fn new() -> Allocator {
+        Allocator {}
     }
-  }
 
-  pub fn initialize(f: &File) {
-    unsafe {
-      TRACE_FD = f.as_raw_fd();
+    pub fn initialize(f: &File) {
+        unsafe {
+            TRACE_FD = f.as_raw_fd();
+        }
     }
-  }
 
-  pub fn activate() {
-    TRACE_ACTIVATE.store(true, Ordering::Relaxed);
-  }
+    pub fn write_to_stdout() {
+        unsafe {
+            TRACE_FD = 0;
+        }
+    }
 
-  pub fn deactivate() {
-    TRACE_ACTIVATE.store(false, Ordering::Relaxed);
-  }
+    pub fn write_to_stderr() {
+        unsafe {
+            TRACE_FD = 1;
+        }
+    }
+
+    pub fn activate() {
+        TRACE_ACTIVATE.store(true, Ordering::Relaxed);
+    }
+
+    pub fn deactivate() {
+        TRACE_ACTIVATE.store(false, Ordering::Relaxed);
+    }
 }
 
 fn to_hex(i: u8) -> u8 {
-  if i > 15 {
-    process::exit(42);
-  }
+    if i > 15 {
+        process::exit(42);
+    }
 
-  if i < 10 {
-    48 + i
-  } else {
-    (i - 10) + 65
-  }
+    if i < 10 {
+        48 + i
+    } else {
+        (i - 10) + 65
+    }
 }
 
 enum Action {
-  Allocating,
-  Deallocating
+    Allocating,
+    Deallocating,
 }
 
 unsafe fn print_size(address: usize, size: usize, action: Action) {
-  if TRACE_FD != -1 && TRACE_ACTIVATE.load(Ordering::Relaxed) {
-    let mut buf: [u8; 100] = mem::uninitialized();
-    let psz = mem::size_of::<usize>();
-    let shr = (psz as u32)*8 - 8;
-    let mut index = 0;
+    if TRACE_FD != -1 && TRACE_ACTIVATE.load(Ordering::Relaxed) {
+        let mut buf: [u8; 100] = mem::MaybeUninit::uninit().assume_init();
+        let psz = mem::size_of::<usize>();
+        let shr = (psz as u32) * 8 - 8;
 
-    let mut counter = 8;
+        let mut index = 0;
+        let mut counter = 8;
 
-    let c = time::precise_time_ns() as usize;
-    loop {
-      if counter == 0 {
-        break;
-      }
+        let c = time::precise_time_ns() as usize;
 
-      let current = ((c.overflowing_shl(64 - 8*counter as u32).0).overflowing_shr(shr).0) as u8;
-      buf[index] = to_hex(current >> 4);
-      buf[index+1] = to_hex( (current << 4) >> 4);
+        loop {
+            if counter == 0 {
+                break;
+            }
 
-      counter -= 1;
-      index += 2;
+            let current = ((c.overflowing_shl(64 - 8 * counter as u32).0)
+                .overflowing_shr(shr)
+                .0) as u8;
+            buf[index] = to_hex(current >> 4);
+            buf[index + 1] = to_hex((current << 4) >> 4);
+
+            counter -= 1;
+            index += 2;
+        }
+
+        buf[index] = b' ';
+
+        index += 1;
+
+        match action {
+            Action::Allocating => buf[index] = b'A',
+            Action::Deallocating => buf[index] = b'D',
+        };
+
+        buf[index + 1] = b' ';
+
+        index += 2;
+        counter = 8;
+
+        let c = address;
+
+        loop {
+            if counter == 0 {
+                break;
+            }
+
+            let current = ((c.overflowing_shl(64 - 8 * counter as u32).0)
+                .overflowing_shr(shr)
+                .0) as u8;
+
+            buf[index] = to_hex(current >> 4);
+            buf[index + 1] = to_hex((current << 4) >> 4);
+
+            counter -= 1;
+            index += 2;
+        }
+
+        buf[index] = b' ';
+
+        index += 1;
+        counter = 8;
+
+        loop {
+            if counter == 0 {
+                break;
+            }
+
+            let current = ((size.overflowing_shl(64 - 8 * counter as u32).0)
+                .overflowing_shr(shr)
+                .0) as u8;
+
+            buf[index] = to_hex(current >> 4);
+            buf[index + 1] = to_hex((current << 4) >> 4);
+
+            counter -= 1;
+            index += 2;
+        }
+        buf[index] = b'\n';
+
+        libc::write(TRACE_FD, buf.as_ptr() as *const c_void, index + 1);
     }
-
-    buf[index] = b' ';
-    index += 1;
-
-    match action {
-      Action::Allocating => buf[index] = b'A',
-      Action::Deallocating => buf[index] = b'D',
-    };
-
-    buf[index+1] = b' ';
-    index += 2;
-
-    counter = 8;
-    let c = address;
-    loop {
-      if counter == 0 {
-        break;
-      }
-
-      let current = ((c.overflowing_shl(64 - 8*counter as u32).0).overflowing_shr(shr).0) as u8;
-      buf[index] = to_hex(current >> 4);
-      buf[index+1] = to_hex( (current << 4) >> 4);
-
-      counter -= 1;
-      index += 2;
-    }
-
-    buf[index] = b' ';
-    index += 1;
-
-    counter = 8;
-    loop {
-      if counter == 0 {
-        break;
-      }
-
-      let current = ((size.overflowing_shl(64 - 8*counter as u32).0).overflowing_shr(shr).0) as u8;
-      buf[index] = to_hex(current >> 4);
-      buf[index+1] = to_hex( (current << 4) >> 4);
-
-      counter -= 1;
-      index += 2;
-    }
-    buf[index] = b'\n';
-
-    libc::write(TRACE_FD,
-      buf.as_ptr() as *const c_void,
-      index+1);
-      //buf.len());
-  }
-
 }
 
 unsafe impl<'a> Alloc for &'a Allocator {
-  unsafe fn alloc(&mut self, layout: Layout) -> Result<*mut u8, AllocErr> {
-    let size = layout.size();
-    let res = System.alloc(layout);
-    if let Ok(p) = res {
-      print_size(p as usize, size, Action::Allocating);
-    }
-    res
-  }
+    unsafe fn alloc(&mut self, layout: Layout) -> Result<NonNull<u8>, AllocErr> {
+        let size = layout.size();
+        let res = System.alloc(layout);
 
-  unsafe fn dealloc(&mut self, ptr: *mut u8, layout: Layout) {
-    print_size(ptr as usize, layout.size(), Action::Deallocating);
-    System.dealloc(ptr, layout)
-  }
+        print_size(res as usize, size, Action::Allocating);
+
+        Ok(NonNull::new(res).unwrap())
+    }
+
+    unsafe fn dealloc(&mut self, ptr: std::ptr::NonNull<u8>, layout: Layout) {
+        let ptr = ptr.as_ptr();
+
+        print_size(ptr as usize, layout.size(), Action::Deallocating);
+
+        System.dealloc(ptr, layout)
+    }
 }
 
+unsafe impl GlobalAlloc for Allocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let size = layout.size();
+        let ptr = System.alloc(layout);
+
+        print_size(ptr as usize, size, Action::Allocating);
+
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        print_size(ptr as usize, layout.size(), Action::Deallocating);
+
+        System.dealloc(ptr, layout)
+    }
+}


### PR DESCRIPTION
Made it work with latest nightly. Also added support for logging to stdout or stderr via `write_to_stdout` and `write_to_stderr`, respectively.

Added impl for GlobalAlloc to support global_allocator. Alloc & GlobalAlloc now differ as Alloc methods (alloc/dealloc) must return `NonNull` as opposed to simply `*mut u8`.

✌️